### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/src/services/falkordb.service.ts
+++ b/src/services/falkordb.service.ts
@@ -40,7 +40,7 @@ class FalkorDBService {
       const result = await graph.query(query, params);
       return result;
     } catch (error) {
-      console.error(`Error executing FalkorDB query on graph ${graphName}:`, error);
+      console.error('Error executing FalkorDB query on graph %s:', graphName, error);
       throw error;
     }
   }

--- a/src/services/falkordb.service.ts
+++ b/src/services/falkordb.service.ts
@@ -40,7 +40,8 @@ class FalkorDBService {
       const result = await graph.query(query, params);
       return result;
     } catch (error) {
-      console.error('Error executing FalkorDB query on graph %s:', graphName, error);
+      const sanitizedGraphName = graphName.replace(/\n|\r/g, "");
+      console.error('Error executing FalkorDB query on graph %s:', sanitizedGraphName, error);
       throw error;
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/FalkorDB-MCP-Server/security/code-scanning/1](https://github.com/FalkorDB/FalkorDB-MCP-Server/security/code-scanning/1)

To fix the problem, we should ensure that the `graphName` is properly sanitized before being used in the format string. The best way to do this is to use a `%s` specifier in the format string and pass the `graphName` as a corresponding argument. This approach ensures that the `graphName` is treated as a string and prevents any unexpected format specifiers from being processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved error messaging to enhance clarity during error scenarios without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->