### PR TITLE
feat(tools): add schema discovery tools (get_graph_schema, get_node_schema, get_relationship_schema)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,11 +75,6 @@ src/
 | `get_relationship_schema` | Sample relationships of a type and rank their property keys by frequency |
 
 Schema-discovery tools (`get_graph_schema`, `get_node_schema`, `get_relationship_schema`) always execute via `executeReadOnlyQuery` (`GRAPH.RO_QUERY`), since discovery is inherently read-only and must work on replica/read-only deployments.
-| `get_graph_schema` | Get node labels, relationship types, and (optional, bounded) connection topology for a graph |
-| `get_node_schema` | Sample nodes of a label and rank their property keys by frequency (reveals the de-facto schema) |
-| `get_relationship_schema` | Sample relationships of a type and rank their property keys by frequency |
-
-Schema-discovery tools (`get_graph_schema`, `get_node_schema`, `get_relationship_schema`) always execute via `executeReadOnlyQuery` (`GRAPH.RO_QUERY`), since discovery is inherently read-only and must work on replica/read-only deployments.
 
 ### MCP Resources
 - `graph_list` — provides a markdown-formatted listing of all graphs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,16 @@ src/
 | `query_graph_readonly` | Execute read-only OpenCypher queries |
 | `list_graphs` | List all available graphs in the database |
 | `delete_graph` | Delete a specific graph |
+| `get_graph_schema` | Get node labels, relationship types, and (optional, bounded) connection topology for a graph |
+| `get_node_schema` | Sample nodes of a label and rank their property keys by frequency (reveals the de-facto schema) |
+| `get_relationship_schema` | Sample relationships of a type and rank their property keys by frequency |
+
+Schema-discovery tools (`get_graph_schema`, `get_node_schema`, `get_relationship_schema`) always execute via `executeReadOnlyQuery` (`GRAPH.RO_QUERY`), since discovery is inherently read-only and must work on replica/read-only deployments.
+| `get_graph_schema` | Get node labels, relationship types, and (optional, bounded) connection topology for a graph |
+| `get_node_schema` | Sample nodes of a label and rank their property keys by frequency (reveals the de-facto schema) |
+| `get_relationship_schema` | Sample relationships of a type and rank their property keys by frequency |
+
+Schema-discovery tools (`get_graph_schema`, `get_node_schema`, `get_relationship_schema`) always execute via `executeReadOnlyQuery` (`GRAPH.RO_QUERY`), since discovery is inherently read-only and must work on replica/read-only deployments.
 
 ### MCP Resources
 - `graph_list` — provides a markdown-formatted listing of all graphs

--- a/README.md
+++ b/README.md
@@ -182,9 +182,19 @@ There's also a dedicated `query_graph_readonly` tool that always executes querie
 ### 📊 Explore Structure
 ```text
 "List all available graphs"
-"Show me the structure of the user_data graph"
+"Show me the schema of the movies graph"
+"What properties do Person nodes usually have in the movies graph?"
+"What properties are on ACTED_IN relationships?"
 "Delete the old_test graph"
 ```
+
+**Schema discovery:** FalkorDB is schemaless, so three tools help an agent orient itself before querying:
+- `get_graph_schema` — returns node labels, relationship types, and (optionally) the connection topology (`source label → relationship type → target label`). Topology is derived from a bounded sample of relationships (`connectionSampleSize`, default `10000`) and can be turned off with `includeConnections: false` on very large graphs.
+- `get_node_schema` / `get_relationship_schema` — sample up to `sampleSize` (default `100`) nodes/relationships of a given label/type and rank their property keys by frequency, returning the actual `sampledCount` alongside `requestedSampleSize`. Useful for spotting property naming drift.
+
+All three schema tools always execute read-only (`GRAPH.RO_QUERY`), so they are safe to run against replica/read-only deployments.
+
+A typical orientation workflow is: `list_graphs → get_graph_schema → get_node_schema / get_relationship_schema → query_graph`.
 
 ## 🛠️ Development
 

--- a/README.md
+++ b/README.md
@@ -184,12 +184,12 @@ There's also a dedicated `query_graph_readonly` tool that always executes querie
 "List all available graphs"
 "Show me the schema of the movies graph"
 "What properties do Person nodes usually have in the movies graph?"
-"What properties are on ACTED_IN relationships?"
+"What properties are on ACTED_IN relationships in the movies graph?"
 "Delete the old_test graph"
 ```
 
 **Schema discovery:** FalkorDB is schemaless, so three tools help an agent orient itself before querying:
-- `get_graph_schema` — returns node labels, relationship types, and (optionally) the connection topology (`source label → relationship type → target label`). Topology is derived from a bounded sample of relationships (`connectionSampleSize`, default `10000`) and can be turned off with `includeConnections: false` on very large graphs.
+- `get_graph_schema` — returns node labels, relationship types, and (optionally) the connection topology. Each connection is `{ source, relationship, target }` where `source` and `target` are **arrays** of node labels (a node may have multiple labels) and `relationship` is the relationship type. Topology is derived from a bounded sample of relationships (`connectionSampleSize`, default `10000`) and can be turned off with `includeConnections: false` on very large graphs.
 - `get_node_schema` / `get_relationship_schema` — sample up to `sampleSize` (default `100`) nodes/relationships of a given label/type and rank their property keys by frequency, returning the actual `sampledCount` alongside `requestedSampleSize`. Useful for spotting property naming drift.
 
 All three schema tools always execute read-only (`GRAPH.RO_QUERY`), so they are safe to run against replica/read-only deployments.

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -252,6 +252,15 @@ describe('MCP Schema Tools', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    // Reset shared mock config so these tests don't depend on state left by
+    // earlier describe blocks (prevents order-dependent flakes).
+    mockConfig = {
+      falkorDB: {
+        defaultReadOnly: false,
+        strictReadOnly: false,
+      }
+    };
+
     server = {
       registerTool: jest.fn((name, _schema, handler) => {
         if (name === 'get_graph_schema') getGraphSchemaHandler = handler;
@@ -326,6 +335,21 @@ describe('MCP Schema Tools', () => {
       );
     });
 
+    it('should not throw when the driver returns a result without a data field', async () => {
+      // falkordb GraphReply.data is optional (undefined for empty replies)
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({ metadata: [] })
+        .mockResolvedValueOnce({ metadata: [] })
+        .mockResolvedValueOnce({ metadata: [] });
+
+      const result = await getGraphSchemaHandler({ graphName: 'myGraph' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.nodeLabels).toEqual([]);
+      expect(parsed.relationshipTypes).toEqual([]);
+      expect(parsed.connections).toEqual([]);
+    });
+
     it('should reject empty graph name', async () => {
       await expect(getGraphSchemaHandler({ graphName: '' }))
         .rejects.toThrow('Graph name is required and cannot be empty');
@@ -385,6 +409,19 @@ describe('MCP Schema Tools', () => {
 
       expect(parsed.sampledCount).toBe(0);
       expect(parsed.properties).toEqual([]);
+    });
+
+    it('should not throw when the driver returns results without a data field', async () => {
+      // falkordb GraphReply.data is optional (undefined for empty replies)
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({ metadata: [] })
+        .mockResolvedValueOnce({ metadata: [] });
+
+      const result = await getNodeSchemaHandler({ graphName: 'myGraph', label: 'Person' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.properties).toEqual([]);
+      expect(parsed.sampledCount).toBe(0);
     });
 
     it('should respect a custom sampleSize', async () => {

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -56,10 +56,8 @@ describe('MCP Tools - Strict Read-Only Mode', () => {
 
     // Create a minimal mock server that captures tool handlers
     server = {
-      registerTool: jest.fn((name, schema, handler) => {
-        if (name === 'query_graph') {
-          queryGraphHandler = handler;
-        }
+      registerTool: jest.fn((name, _schema, handler) => {
+        if (name === 'query_graph') queryGraphHandler = handler;
       }),
     } as any;
 
@@ -255,7 +253,7 @@ describe('MCP Schema Tools', () => {
     jest.clearAllMocks();
 
     server = {
-      registerTool: jest.fn((name, schema, handler) => {
+      registerTool: jest.fn((name, _schema, handler) => {
         if (name === 'get_graph_schema') getGraphSchemaHandler = handler;
         if (name === 'get_node_schema') getNodePropertiesHandler = handler;
         if (name === 'get_relationship_schema') getRelationshipPropertiesHandler = handler;

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -244,3 +244,133 @@ describe('MCP Tools - Strict Read-Only Mode', () => {
     });
   });
 });
+
+describe('MCP Schema Tools', () => {
+  let server: McpServer;
+  let getGraphSchemaHandler: any;
+  let getNodePropertiesHandler: any;
+  let getRelationshipPropertiesHandler: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    server = {
+      registerTool: jest.fn((name, schema, handler) => {
+        if (name === 'get_graph_schema') getGraphSchemaHandler = handler;
+        if (name === 'get_node_schema') getNodePropertiesHandler = handler;
+        if (name === 'get_relationship_schema') getRelationshipPropertiesHandler = handler;
+      }),
+    } as any;
+
+    registerAllTools(server);
+  });
+
+  describe('get_graph_schema', () => {
+    it('should return schema with labels, relationship types, and connections', async () => {
+      (falkorDBService.executeQuery as jest.Mock)
+        .mockResolvedValueOnce({ data: [{ label: 'Person' }, { label: 'Movie' }] })
+        .mockResolvedValueOnce({ data: [{ relationshipType: 'ACTED_IN' }] })
+        .mockResolvedValueOnce({ data: [{ source: ['Person'], relationship: 'ACTED_IN', target: ['Movie'] }] });
+
+      const result = await getGraphSchemaHandler({ graphName: 'myGraph' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.nodeLabels).toEqual(['Person', 'Movie']);
+      expect(parsed.relationshipTypes).toEqual(['ACTED_IN']);
+      expect(parsed.connections).toHaveLength(1);
+    });
+
+    it('should reject empty graph name', async () => {
+      await expect(getGraphSchemaHandler({ graphName: '' }))
+        .rejects.toThrow('Graph name is required and cannot be empty');
+    });
+  });
+
+  describe('get_node_properties', () => {
+    it('should aggregate properties across sampled nodes ranked by frequency', async () => {
+      (falkorDBService.executeQuery as jest.Mock).mockResolvedValue({
+        data: [
+          { property: 'name', frequency: 98 },
+          { property: 'age', frequency: 45 },
+          { property: 'nickname', frequency: 3 },
+        ]
+      });
+
+      const result = await getNodePropertiesHandler({ graphName: 'myGraph', label: 'Person' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(falkorDBService.executeQuery).toHaveBeenCalledWith(
+        'myGraph',
+        'MATCH (n:Person) WITH n LIMIT 100 UNWIND keys(n) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC'
+      );
+      expect(parsed.label).toBe('Person');
+      expect(parsed.sampleSize).toBe(100);
+      expect(parsed.properties[0]).toEqual({ property: 'name', frequency: 98 });
+      expect(parsed.properties[2]).toEqual({ property: 'nickname', frequency: 3 });
+    });
+
+    it('should respect a custom sampleSize', async () => {
+      (falkorDBService.executeQuery as jest.Mock).mockResolvedValue({ data: [] });
+
+      await getNodePropertiesHandler({ graphName: 'myGraph', label: 'Person', sampleSize: 500 });
+
+      expect(falkorDBService.executeQuery).toHaveBeenCalledWith(
+        'myGraph',
+        'MATCH (n:Person) WITH n LIMIT 500 UNWIND keys(n) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC'
+      );
+    });
+
+    it('should reject invalid label characters', async () => {
+      await expect(getNodePropertiesHandler({ graphName: 'myGraph', label: 'Person; DROP' }))
+        .rejects.toThrow();
+    });
+
+    it('should reject empty graph name', async () => {
+      await expect(getNodePropertiesHandler({ graphName: '', label: 'Person' }))
+        .rejects.toThrow('Graph name is required and cannot be empty');
+    });
+  });
+
+  describe('get_relationship_properties', () => {
+    it('should aggregate properties across sampled relationships ranked by frequency', async () => {
+      (falkorDBService.executeQuery as jest.Mock).mockResolvedValue({
+        data: [
+          { property: 'role', frequency: 72 },
+          { property: 'year', frequency: 18 },
+        ]
+      });
+
+      const result = await getRelationshipPropertiesHandler({ graphName: 'myGraph', relationshipType: 'ACTED_IN' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(falkorDBService.executeQuery).toHaveBeenCalledWith(
+        'myGraph',
+        'MATCH ()-[r:ACTED_IN]->() WITH r LIMIT 100 UNWIND keys(r) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC'
+      );
+      expect(parsed.relationshipType).toBe('ACTED_IN');
+      expect(parsed.sampleSize).toBe(100);
+      expect(parsed.properties[0]).toEqual({ property: 'role', frequency: 72 });
+    });
+
+    it('should respect a custom sampleSize', async () => {
+      (falkorDBService.executeQuery as jest.Mock).mockResolvedValue({ data: [] });
+
+      await getRelationshipPropertiesHandler({ graphName: 'myGraph', relationshipType: 'ACTED_IN', sampleSize: 250 });
+
+      expect(falkorDBService.executeQuery).toHaveBeenCalledWith(
+        'myGraph',
+        'MATCH ()-[r:ACTED_IN]->() WITH r LIMIT 250 UNWIND keys(r) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC'
+      );
+    });
+
+    it('should reject invalid relationship type characters', async () => {
+      await expect(getRelationshipPropertiesHandler({ graphName: 'myGraph', relationshipType: 'ACTED_IN; DROP' }))
+        .rejects.toThrow();
+    });
+
+    it('should reject empty graph name', async () => {
+      await expect(getRelationshipPropertiesHandler({ graphName: '', relationshipType: 'ACTED_IN' }))
+        .rejects.toThrow('Graph name is required and cannot be empty');
+    });
+  });
+});

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -246,8 +246,8 @@ describe('MCP Tools - Strict Read-Only Mode', () => {
 describe('MCP Schema Tools', () => {
   let server: McpServer;
   let getGraphSchemaHandler: any;
-  let getNodePropertiesHandler: any;
-  let getRelationshipPropertiesHandler: any;
+  let getNodeSchemaHandler: any;
+  let getRelationshipSchemaHandler: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -255,8 +255,8 @@ describe('MCP Schema Tools', () => {
     server = {
       registerTool: jest.fn((name, _schema, handler) => {
         if (name === 'get_graph_schema') getGraphSchemaHandler = handler;
-        if (name === 'get_node_schema') getNodePropertiesHandler = handler;
-        if (name === 'get_relationship_schema') getRelationshipPropertiesHandler = handler;
+        if (name === 'get_node_schema') getNodeSchemaHandler = handler;
+        if (name === 'get_relationship_schema') getRelationshipSchemaHandler = handler;
       }),
     } as any;
 
@@ -265,7 +265,7 @@ describe('MCP Schema Tools', () => {
 
   describe('get_graph_schema', () => {
     it('should return schema with labels, relationship types, and connections', async () => {
-      (falkorDBService.executeQuery as jest.Mock)
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
         .mockResolvedValueOnce({ data: [{ label: 'Person' }, { label: 'Movie' }] })
         .mockResolvedValueOnce({ data: [{ relationshipType: 'ACTED_IN' }] })
         .mockResolvedValueOnce({ data: [{ source: ['Person'], relationship: 'ACTED_IN', target: ['Movie'] }] });
@@ -276,6 +276,54 @@ describe('MCP Schema Tools', () => {
       expect(parsed.nodeLabels).toEqual(['Person', 'Movie']);
       expect(parsed.relationshipTypes).toEqual(['ACTED_IN']);
       expect(parsed.connections).toHaveLength(1);
+      expect(parsed.connectionSampleSize).toBe(10000);
+    });
+
+    it('should execute all queries in read-only mode (never read-write)', async () => {
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({ data: [{ label: 'Person' }] })
+        .mockResolvedValueOnce({ data: [{ relationshipType: 'ACTED_IN' }] })
+        .mockResolvedValueOnce({ data: [] });
+
+      await getGraphSchemaHandler({ graphName: 'myGraph' });
+
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith('myGraph', 'CALL db.labels()');
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith('myGraph', 'CALL db.relationshipTypes()');
+      expect(falkorDBService.executeQuery).not.toHaveBeenCalled();
+    });
+
+    it('should bound the connection topology scan and honor a custom connectionSampleSize', async () => {
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({ data: [{ label: 'Person' }] })
+        .mockResolvedValueOnce({ data: [{ relationshipType: 'ACTED_IN' }] })
+        .mockResolvedValueOnce({ data: [] });
+
+      const result = await getGraphSchemaHandler({ graphName: 'myGraph', connectionSampleSize: 250 });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith(
+        'myGraph',
+        'MATCH (a)-[r]->(b) WITH a, r, b LIMIT 250 RETURN DISTINCT labels(a) AS source, type(r) AS relationship, labels(b) AS target'
+      );
+      expect(parsed.connectionSampleSize).toBe(250);
+    });
+
+    it('should skip the connection topology scan when includeConnections is false', async () => {
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({ data: [{ label: 'Person' }] })
+        .mockResolvedValueOnce({ data: [{ relationshipType: 'ACTED_IN' }] });
+
+      const result = await getGraphSchemaHandler({ graphName: 'myGraph', includeConnections: false });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.connections).toEqual([]);
+      expect(parsed.connectionSampleSize).toBeUndefined();
+      // only the labels and relationshipTypes queries run — no topology scan
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledTimes(2);
+      expect(falkorDBService.executeReadOnlyQuery).not.toHaveBeenCalledWith(
+        'myGraph',
+        expect.stringContaining('MATCH (a)-[r]->(b)')
+      );
     });
 
     it('should reject empty graph name', async () => {
@@ -284,90 +332,142 @@ describe('MCP Schema Tools', () => {
     });
   });
 
-  describe('get_node_properties', () => {
-    it('should aggregate properties across sampled nodes ranked by frequency', async () => {
-      (falkorDBService.executeQuery as jest.Mock).mockResolvedValue({
-        data: [
-          { property: 'name', frequency: 98 },
-          { property: 'age', frequency: 45 },
-          { property: 'nickname', frequency: 3 },
-        ]
-      });
+  describe('get_node_schema', () => {
+    it('should aggregate properties ranked by frequency and report the actual sampled count', async () => {
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({
+          data: [
+            { property: 'name', frequency: 98 },
+            { property: 'age', frequency: 45 },
+            { property: 'nickname', frequency: 3 },
+          ]
+        })
+        .mockResolvedValueOnce({ data: [{ sampledCount: 98 }] });
 
-      const result = await getNodePropertiesHandler({ graphName: 'myGraph', label: 'Person' });
+      const result = await getNodeSchemaHandler({ graphName: 'myGraph', label: 'Person' });
       const parsed = JSON.parse(result.content[0].text);
 
-      expect(falkorDBService.executeQuery).toHaveBeenCalledWith(
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith(
         'myGraph',
         'MATCH (n:Person) WITH n LIMIT 100 UNWIND keys(n) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC'
       );
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith(
+        'myGraph',
+        'MATCH (n:Person) WITH n LIMIT 100 RETURN count(n) AS sampledCount'
+      );
+      expect(falkorDBService.executeQuery).not.toHaveBeenCalled();
       expect(parsed.label).toBe('Person');
-      expect(parsed.sampleSize).toBe(100);
+      expect(parsed.requestedSampleSize).toBe(100);
+      expect(parsed.sampledCount).toBe(98);
       expect(parsed.properties[0]).toEqual({ property: 'name', frequency: 98 });
       expect(parsed.properties[2]).toEqual({ property: 'nickname', frequency: 3 });
     });
 
+    it('should report sampledCount below requestedSampleSize when the graph has fewer nodes', async () => {
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({ data: [{ property: 'name', frequency: 4 }] })
+        .mockResolvedValueOnce({ data: [{ sampledCount: 4 }] });
+
+      const result = await getNodeSchemaHandler({ graphName: 'myGraph', label: 'Person' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.requestedSampleSize).toBe(100);
+      expect(parsed.sampledCount).toBe(4);
+    });
+
+    it('should default sampledCount to 0 when the count query returns no rows', async () => {
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({ data: [] })
+        .mockResolvedValueOnce({ data: [] });
+
+      const result = await getNodeSchemaHandler({ graphName: 'myGraph', label: 'Person' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.sampledCount).toBe(0);
+      expect(parsed.properties).toEqual([]);
+    });
+
     it('should respect a custom sampleSize', async () => {
-      (falkorDBService.executeQuery as jest.Mock).mockResolvedValue({ data: [] });
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({ data: [] })
+        .mockResolvedValueOnce({ data: [{ sampledCount: 0 }] });
 
-      await getNodePropertiesHandler({ graphName: 'myGraph', label: 'Person', sampleSize: 500 });
+      await getNodeSchemaHandler({ graphName: 'myGraph', label: 'Person', sampleSize: 500 });
 
-      expect(falkorDBService.executeQuery).toHaveBeenCalledWith(
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith(
         'myGraph',
         'MATCH (n:Person) WITH n LIMIT 500 UNWIND keys(n) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC'
+      );
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith(
+        'myGraph',
+        'MATCH (n:Person) WITH n LIMIT 500 RETURN count(n) AS sampledCount'
       );
     });
 
     it('should reject invalid label characters', async () => {
-      await expect(getNodePropertiesHandler({ graphName: 'myGraph', label: 'Person; DROP' }))
+      await expect(getNodeSchemaHandler({ graphName: 'myGraph', label: 'Person; DROP' }))
         .rejects.toThrow();
     });
 
     it('should reject empty graph name', async () => {
-      await expect(getNodePropertiesHandler({ graphName: '', label: 'Person' }))
+      await expect(getNodeSchemaHandler({ graphName: '', label: 'Person' }))
         .rejects.toThrow('Graph name is required and cannot be empty');
     });
   });
 
-  describe('get_relationship_properties', () => {
-    it('should aggregate properties across sampled relationships ranked by frequency', async () => {
-      (falkorDBService.executeQuery as jest.Mock).mockResolvedValue({
-        data: [
-          { property: 'role', frequency: 72 },
-          { property: 'year', frequency: 18 },
-        ]
-      });
+  describe('get_relationship_schema', () => {
+    it('should aggregate properties ranked by frequency and report the actual sampled count', async () => {
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({
+          data: [
+            { property: 'role', frequency: 72 },
+            { property: 'year', frequency: 18 },
+          ]
+        })
+        .mockResolvedValueOnce({ data: [{ sampledCount: 72 }] });
 
-      const result = await getRelationshipPropertiesHandler({ graphName: 'myGraph', relationshipType: 'ACTED_IN' });
+      const result = await getRelationshipSchemaHandler({ graphName: 'myGraph', relationshipType: 'ACTED_IN' });
       const parsed = JSON.parse(result.content[0].text);
 
-      expect(falkorDBService.executeQuery).toHaveBeenCalledWith(
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith(
         'myGraph',
         'MATCH ()-[r:ACTED_IN]->() WITH r LIMIT 100 UNWIND keys(r) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC'
       );
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith(
+        'myGraph',
+        'MATCH ()-[r:ACTED_IN]->() WITH r LIMIT 100 RETURN count(r) AS sampledCount'
+      );
+      expect(falkorDBService.executeQuery).not.toHaveBeenCalled();
       expect(parsed.relationshipType).toBe('ACTED_IN');
-      expect(parsed.sampleSize).toBe(100);
+      expect(parsed.requestedSampleSize).toBe(100);
+      expect(parsed.sampledCount).toBe(72);
       expect(parsed.properties[0]).toEqual({ property: 'role', frequency: 72 });
     });
 
     it('should respect a custom sampleSize', async () => {
-      (falkorDBService.executeQuery as jest.Mock).mockResolvedValue({ data: [] });
+      (falkorDBService.executeReadOnlyQuery as jest.Mock)
+        .mockResolvedValueOnce({ data: [] })
+        .mockResolvedValueOnce({ data: [{ sampledCount: 0 }] });
 
-      await getRelationshipPropertiesHandler({ graphName: 'myGraph', relationshipType: 'ACTED_IN', sampleSize: 250 });
+      await getRelationshipSchemaHandler({ graphName: 'myGraph', relationshipType: 'ACTED_IN', sampleSize: 250 });
 
-      expect(falkorDBService.executeQuery).toHaveBeenCalledWith(
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith(
         'myGraph',
         'MATCH ()-[r:ACTED_IN]->() WITH r LIMIT 250 UNWIND keys(r) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC'
+      );
+      expect(falkorDBService.executeReadOnlyQuery).toHaveBeenCalledWith(
+        'myGraph',
+        'MATCH ()-[r:ACTED_IN]->() WITH r LIMIT 250 RETURN count(r) AS sampledCount'
       );
     });
 
     it('should reject invalid relationship type characters', async () => {
-      await expect(getRelationshipPropertiesHandler({ graphName: 'myGraph', relationshipType: 'ACTED_IN; DROP' }))
+      await expect(getRelationshipSchemaHandler({ graphName: 'myGraph', relationshipType: 'ACTED_IN; DROP' }))
         .rejects.toThrow();
     });
 
     it('should reject empty graph name', async () => {
-      await expect(getRelationshipPropertiesHandler({ graphName: '', relationshipType: 'ACTED_IN' }))
+      await expect(getRelationshipSchemaHandler({ graphName: '', relationshipType: 'ACTED_IN' }))
         .rejects.toThrow('Graph name is required and cannot be empty');
     });
   });

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -24,7 +24,7 @@ const deleteGraphSchema = {
 
 const getGraphSchemaSchema = {
   graphName: z.string().describe("Name of the graph. Use the list_graphs tool to discover available graphs."),
-  includeConnections: z.boolean().optional().describe("If true (default), include the relationship connection topology (source label → relationship type → target label). This is derived from a bounded sample of relationships; set to false to skip it entirely on very large graphs to reduce cost and response size."),
+  includeConnections: z.boolean().optional().describe("If true (default), include the relationship connection topology. Each connection is { source, relationship, target } where source and target are arrays of node labels (a node may have multiple labels) and relationship is the relationship type. Derived from a bounded sample of relationships; set to false to skip it entirely on very large graphs to reduce cost and response size."),
   connectionSampleSize: z.number().int().min(1).max(100000).optional().describe("Maximum number of relationships to scan when deriving connection topology (default: 10000). Bounds query cost on large graphs; topology derived from the sample may be incomplete if the graph has more relationships than this."),
 };
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -22,6 +22,22 @@ const deleteGraphSchema = {
   confirmDelete: z.literal(true).describe("Must be set to true to confirm deletion. This is a safety measure to prevent accidental data loss."),
 };
 
+const getGraphSchemaSchema = {
+  graphName: z.string().describe("Name of the graph. Use the list_graphs tool to discover available graphs."),
+};
+
+const getNodeSchemaSchema = {
+  graphName: z.string().describe("Name of the graph. Use the list_graphs tool to discover available graphs."),
+  label: z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/).describe("Node label to inspect"),
+  sampleSize: z.number().int().min(1).max(10000).optional().describe("Number of nodes to sample (default: 100). Larger values improve property coverage at the cost of query time."),
+};
+
+const getRelationshipSchemaSchema = {
+  graphName: z.string().describe("Name of the graph. Use the list_graphs tool to discover available graphs."),
+  relationshipType: z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/).describe("Relationship type to inspect"),
+  sampleSize: z.number().int().min(1).max(10000).optional().describe("Number of relationships to sample (default: 100). Larger values improve property coverage at the cost of query time."),
+};
+
 function registerQueryGraphTool(server: McpServer): void {
   server.registerTool(
     "query_graph",
@@ -199,10 +215,145 @@ function registerDeleteGraphTool(server: McpServer): void {
 }
 
 
+function registerGetGraphSchemaTool(server: McpServer): void {
+  server.registerTool(
+    "get_graph_schema",
+    {
+      title: "Get Graph Schema",
+      description: "Get the schema of a graph including node labels and relationship types to understand the graph structure before executing a query.",
+      inputSchema: getGraphSchemaSchema as any,
+    },
+    async (args: unknown) => {
+      const { graphName } = z.object(getGraphSchemaSchema).parse(args);
+      try {
+        if (!graphName?.trim()) {
+          throw new AppError(CommonErrors.INVALID_INPUT, 'Graph name is required and cannot be empty', true);
+        }
+
+        const labelsResult = await falkorDBService.executeQuery(graphName, "CALL db.labels()") as any;
+        const labels = labelsResult.data.map((r: any) => r['label']);
+
+        const typesResult = await falkorDBService.executeQuery(graphName, "CALL db.relationshipTypes()") as any;
+        const relationshipTypes = typesResult.data.map((r: any) => r['relationshipType']);
+
+        const schemaResult = await falkorDBService.executeQuery(
+          graphName,
+          "MATCH (a)-[r]->(b) RETURN DISTINCT labels(a) as source, type(r) as relationship, labels(b) as target"
+        ) as any;
+
+        const schema = {
+          nodeLabels: labels,
+          relationshipTypes,
+          connections: schemaResult.data,
+        };
+
+        await logger.debug('Get graph schema tool executed successfully', { graphName });
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(schema, null, 2)
+          }]
+        };
+      } catch (error) {
+        await logger.error('Get graph schema tool execution failed', error instanceof Error ? error : new Error(String(error)), { graphName });
+        throw error;
+      }
+    }
+  );
+}
+
+function registerGetNodeSchemaTool(server: McpServer): void {
+  server.registerTool(
+    "get_node_schema",
+    {
+      title: "Get Node Schema",
+      description: "Sample up to N nodes of a given label and aggregate their property keys by how many nodes carry each one (descending). Use this before adding a new property to verify a similar one does not already exist — especially valuable in schemaless graphs where property naming can drift across subsets of nodes.",
+      inputSchema: getNodeSchemaSchema as any,
+    },
+    async (args: unknown) => {
+      const { graphName, label, sampleSize = 100 } = z.object(getNodeSchemaSchema).parse(args);
+      try {
+        if (!graphName?.trim()) {
+          throw new AppError(CommonErrors.INVALID_INPUT, 'Graph name is required and cannot be empty', true);
+        }
+
+        const result = await falkorDBService.executeQuery(
+          graphName,
+          `MATCH (n:${label}) WITH n LIMIT ${sampleSize} UNWIND keys(n) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC`
+        ) as any;
+
+        const response = {
+          label,
+          sampleSize,
+          properties: result.data,
+        };
+
+        await logger.debug('Get node schema tool executed successfully', { graphName, label, sampleSize });
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        await logger.error('Get node schema tool execution failed', error instanceof Error ? error : new Error(String(error)), { graphName, label });
+        throw error;
+      }
+    }
+  );
+}
+
+function registerGetRelationshipSchemaTool(server: McpServer): void {
+  server.registerTool(
+    "get_relationship_schema",
+    {
+      title: "Get Relationship Schema",
+      description: "Sample up to N relationships of a given type and aggregate their property keys by how many relationships carry each one (descending). Use this before adding a new property to verify a similar one does not already exist — especially valuable in schemaless graphs where property naming can drift across subsets of relationships.",
+      inputSchema: getRelationshipSchemaSchema as any,
+    },
+    async (args: unknown) => {
+      const { graphName, relationshipType, sampleSize = 100 } = z.object(getRelationshipSchemaSchema).parse(args);
+      try {
+        if (!graphName?.trim()) {
+          throw new AppError(CommonErrors.INVALID_INPUT, 'Graph name is required and cannot be empty', true);
+        }
+
+        const result = await falkorDBService.executeQuery(
+          graphName,
+          `MATCH ()-[r:${relationshipType}]->() WITH r LIMIT ${sampleSize} UNWIND keys(r) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC`
+        ) as any;
+
+        const response = {
+          relationshipType,
+          sampleSize,
+          properties: result.data,
+        };
+
+        await logger.debug('Get relationship schema tool executed successfully', { graphName, relationshipType, sampleSize });
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        await logger.error('Get relationship schema tool execution failed', error instanceof Error ? error : new Error(String(error)), { graphName, relationshipType });
+        throw error;
+      }
+    }
+  );
+}
+
 export default function registerAllTools(server: McpServer): void {
   // Register query_graph tools
   registerQueryGraphTool(server);
   registerQueryGraphReadOnlyTool(server);
   registerListGraphsTool(server);
   registerDeleteGraphTool(server);
+  registerGetGraphSchemaTool(server);
+  registerGetNodeSchemaTool(server);
+  registerGetRelationshipSchemaTool(server);
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -233,10 +233,10 @@ function registerGetGraphSchemaTool(server: McpServer): void {
         }
 
         const labelsResult = await falkorDBService.executeReadOnlyQuery(graphName, "CALL db.labels()") as any;
-        const labels = labelsResult.data.map((r: any) => r['label']);
+        const labels = (labelsResult.data ?? []).map((r: any) => r['label']);
 
         const typesResult = await falkorDBService.executeReadOnlyQuery(graphName, "CALL db.relationshipTypes()") as any;
-        const relationshipTypes = typesResult.data.map((r: any) => r['relationshipType']);
+        const relationshipTypes = (typesResult.data ?? []).map((r: any) => r['relationshipType']);
 
         const schema: {
           nodeLabels: string[];
@@ -254,7 +254,7 @@ function registerGetGraphSchemaTool(server: McpServer): void {
             graphName,
             `MATCH (a)-[r]->(b) WITH a, r, b LIMIT ${connectionSampleSize} RETURN DISTINCT labels(a) AS source, type(r) AS relationship, labels(b) AS target`
           ) as any;
-          schema.connections = schemaResult.data;
+          schema.connections = schemaResult.data ?? [];
           schema.connectionSampleSize = connectionSampleSize;
         }
 
@@ -304,7 +304,7 @@ function registerGetNodeSchemaTool(server: McpServer): void {
           label,
           requestedSampleSize: sampleSize,
           sampledCount,
-          properties: result.data,
+          properties: result.data ?? [],
         };
 
         await logger.debug('Get node schema tool executed successfully', { graphName, label, sampleSize, sampledCount });
@@ -353,7 +353,7 @@ function registerGetRelationshipSchemaTool(server: McpServer): void {
           relationshipType,
           requestedSampleSize: sampleSize,
           sampledCount,
-          properties: result.data,
+          properties: result.data ?? [],
         };
 
         await logger.debug('Get relationship schema tool executed successfully', { graphName, relationshipType, sampleSize, sampledCount });

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -24,6 +24,8 @@ const deleteGraphSchema = {
 
 const getGraphSchemaSchema = {
   graphName: z.string().describe("Name of the graph. Use the list_graphs tool to discover available graphs."),
+  includeConnections: z.boolean().optional().describe("If true (default), include the relationship connection topology (source label → relationship type → target label). This is derived from a bounded sample of relationships; set to false to skip it entirely on very large graphs to reduce cost and response size."),
+  connectionSampleSize: z.number().int().min(1).max(100000).optional().describe("Maximum number of relationships to scan when deriving connection topology (default: 10000). Bounds query cost on large graphs; topology derived from the sample may be incomplete if the graph has more relationships than this."),
 };
 
 const getNodeSchemaSchema = {
@@ -220,34 +222,43 @@ function registerGetGraphSchemaTool(server: McpServer): void {
     "get_graph_schema",
     {
       title: "Get Graph Schema",
-      description: "Get the schema of a graph including node labels and relationship types to understand the graph structure before executing a query.",
+      description: "Get the schema of a graph including node labels, relationship types, and (optionally) the connection topology between them, to understand the graph structure before executing a query. Connection topology is derived from a bounded sample of relationships and can be disabled via includeConnections on very large graphs.",
       inputSchema: getGraphSchemaSchema as any,
     },
     async (args: unknown) => {
-      const { graphName } = z.object(getGraphSchemaSchema).parse(args);
+      const { graphName, includeConnections = true, connectionSampleSize = 10000 } = z.object(getGraphSchemaSchema).parse(args);
       try {
         if (!graphName?.trim()) {
           throw new AppError(CommonErrors.INVALID_INPUT, 'Graph name is required and cannot be empty', true);
         }
 
-        const labelsResult = await falkorDBService.executeQuery(graphName, "CALL db.labels()") as any;
+        const labelsResult = await falkorDBService.executeReadOnlyQuery(graphName, "CALL db.labels()") as any;
         const labels = labelsResult.data.map((r: any) => r['label']);
 
-        const typesResult = await falkorDBService.executeQuery(graphName, "CALL db.relationshipTypes()") as any;
+        const typesResult = await falkorDBService.executeReadOnlyQuery(graphName, "CALL db.relationshipTypes()") as any;
         const relationshipTypes = typesResult.data.map((r: any) => r['relationshipType']);
 
-        const schemaResult = await falkorDBService.executeQuery(
-          graphName,
-          "MATCH (a)-[r]->(b) RETURN DISTINCT labels(a) as source, type(r) as relationship, labels(b) as target"
-        ) as any;
-
-        const schema = {
+        const schema: {
+          nodeLabels: string[];
+          relationshipTypes: string[];
+          connections: unknown[];
+          connectionSampleSize?: number;
+        } = {
           nodeLabels: labels,
           relationshipTypes,
-          connections: schemaResult.data,
+          connections: [],
         };
 
-        await logger.debug('Get graph schema tool executed successfully', { graphName });
+        if (includeConnections) {
+          const schemaResult = await falkorDBService.executeReadOnlyQuery(
+            graphName,
+            `MATCH (a)-[r]->(b) WITH a, r, b LIMIT ${connectionSampleSize} RETURN DISTINCT labels(a) AS source, type(r) AS relationship, labels(b) AS target`
+          ) as any;
+          schema.connections = schemaResult.data;
+          schema.connectionSampleSize = connectionSampleSize;
+        }
+
+        await logger.debug('Get graph schema tool executed successfully', { graphName, includeConnections });
 
         return {
           content: [{
@@ -268,7 +279,7 @@ function registerGetNodeSchemaTool(server: McpServer): void {
     "get_node_schema",
     {
       title: "Get Node Schema",
-      description: "Sample up to N nodes of a given label and aggregate their property keys by how many nodes carry each one (descending). Use this before adding a new property to verify a similar one does not already exist — especially valuable in schemaless graphs where property naming can drift across subsets of nodes.",
+      description: "Sample up to N nodes of a given label and aggregate their property keys by how many nodes carry each one (descending). Interpret each property's frequency relative to the returned sampledCount (the actual number of nodes sampled, which may be less than requestedSampleSize) to detect naming drift — e.g. a property present on only a few of many sampled nodes likely duplicates another under a slightly different name. Especially valuable in schemaless graphs where property naming can drift across subsets of nodes.",
       inputSchema: getNodeSchemaSchema as any,
     },
     async (args: unknown) => {
@@ -278,18 +289,25 @@ function registerGetNodeSchemaTool(server: McpServer): void {
           throw new AppError(CommonErrors.INVALID_INPUT, 'Graph name is required and cannot be empty', true);
         }
 
-        const result = await falkorDBService.executeQuery(
+        const result = await falkorDBService.executeReadOnlyQuery(
           graphName,
           `MATCH (n:${label}) WITH n LIMIT ${sampleSize} UNWIND keys(n) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC`
         ) as any;
 
+        const countResult = await falkorDBService.executeReadOnlyQuery(
+          graphName,
+          `MATCH (n:${label}) WITH n LIMIT ${sampleSize} RETURN count(n) AS sampledCount`
+        ) as any;
+        const sampledCount = countResult.data?.[0]?.sampledCount ?? 0;
+
         const response = {
           label,
-          sampleSize,
+          requestedSampleSize: sampleSize,
+          sampledCount,
           properties: result.data,
         };
 
-        await logger.debug('Get node schema tool executed successfully', { graphName, label, sampleSize });
+        await logger.debug('Get node schema tool executed successfully', { graphName, label, sampleSize, sampledCount });
 
         return {
           content: [{
@@ -310,7 +328,7 @@ function registerGetRelationshipSchemaTool(server: McpServer): void {
     "get_relationship_schema",
     {
       title: "Get Relationship Schema",
-      description: "Sample up to N relationships of a given type and aggregate their property keys by how many relationships carry each one (descending). Use this before adding a new property to verify a similar one does not already exist — especially valuable in schemaless graphs where property naming can drift across subsets of relationships.",
+      description: "Sample up to N relationships of a given type and aggregate their property keys by how many relationships carry each one (descending). Interpret each property's frequency relative to the returned sampledCount (the actual number of relationships sampled, which may be less than requestedSampleSize) to detect naming drift — e.g. a property present on only a few of many sampled relationships likely duplicates another under a slightly different name. Especially valuable in schemaless graphs where property naming can drift across subsets of relationships.",
       inputSchema: getRelationshipSchemaSchema as any,
     },
     async (args: unknown) => {
@@ -320,18 +338,25 @@ function registerGetRelationshipSchemaTool(server: McpServer): void {
           throw new AppError(CommonErrors.INVALID_INPUT, 'Graph name is required and cannot be empty', true);
         }
 
-        const result = await falkorDBService.executeQuery(
+        const result = await falkorDBService.executeReadOnlyQuery(
           graphName,
           `MATCH ()-[r:${relationshipType}]->() WITH r LIMIT ${sampleSize} UNWIND keys(r) AS property RETURN property, count(*) AS frequency ORDER BY frequency DESC`
         ) as any;
 
+        const countResult = await falkorDBService.executeReadOnlyQuery(
+          graphName,
+          `MATCH ()-[r:${relationshipType}]->() WITH r LIMIT ${sampleSize} RETURN count(r) AS sampledCount`
+        ) as any;
+        const sampledCount = countResult.data?.[0]?.sampledCount ?? 0;
+
         const response = {
           relationshipType,
-          sampleSize,
+          requestedSampleSize: sampleSize,
+          sampledCount,
           properties: result.data,
         };
 
-        await logger.debug('Get relationship schema tool executed successfully', { graphName, relationshipType, sampleSize });
+        await logger.debug('Get relationship schema tool executed successfully', { graphName, relationshipType, sampleSize, sampledCount });
 
         return {
           content: [{


### PR DESCRIPTION
## What & why

Closes #120.

FalkorDB is schemaless, which means LLM agents arrive with no prior knowledge of what labels, relationship types, or properties exist in a graph. Without discovery tooling, agents either need to know the structure in advance or write ad-hoc exploratory queries that vary in approach and are token-expensive.

This PR adds three schema discovery tools that form a coherent orientation workflow, designed to run before any substantive query work begins.

## Changes

**`get_graph_schema`** — returns node labels, relationship types, and connection topology in one call. Abstracts FalkorDB-specific procedures (`CALL db.labels()`, `CALL db.relationshipTypes()`) behind a single model-agnostic interface.

**`get_node_schema`** — samples up to N nodes of a given label and aggregates property keys by frequency (descending). Reveals the de-facto property schema that FalkorDB itself does not enforce. Useful for detecting property naming drift before writing or extending data.

**`get_relationship_schema`** — same as above for relationships of a given type.

### Example workflow
```
list_graphs → get_graph_schema → get_node_schema / get_relationship_schema → query_graph
```

### Example: `get_node_schema("movies", "Person", sampleSize=100)`
```json
{
  "label": "Person",
  "requestedSampleSize": 100,
  "sampledCount": 100,
  "properties": [
    { "property": "name",     "frequency": 100 },
    { "property": "born",     "frequency":  87 },
    { "property": "nickname", "frequency":   4 }
  ]
}
```

A property at frequency 4 out of a `sampledCount` of 100 signals naming drift — a variation that likely duplicates an existing property under a slightly different name. (`requestedSampleSize` is the cap you asked for; `sampledCount` is how many nodes were actually sampled, so the ratio stays meaningful even when the graph holds fewer nodes than the cap.)

## Testing

- `npm run lint` — clean
- `npm run build` — clean
- `npm test` — 105/105 passing (includes unit tests for all three new tools: happy path, custom sampleSize, invalid label/relationshipType characters, empty graph name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UbYYhjDYpQ3UTVshhR9k1
